### PR TITLE
modify status to exit with exitcode 3

### DIFF
--- a/src/yaml_server/YamlDaemon.py
+++ b/src/yaml_server/YamlDaemon.py
@@ -181,7 +181,7 @@ class YamlDaemon:
             return 0
         else:
             print "Not running"
-            return 1
+            return 3
 
     def stop(self):
         """


### PR DESCRIPTION
In respect to LSB specifications for init-scripts, a status command should return exitcode 3 if the daemon is stopped.
