### PR TITLE
fix issues with yaml_server restart

### DIFF
--- a/src/yaml_server/YamlServerMain.py
+++ b/src/yaml_server/YamlServerMain.py
@@ -59,6 +59,7 @@ class YamlServerMain(YamlDaemon):
 
     def run(self):
         try:
+            SocketServer.TCPServer.allow_reuse_address = True
             httpd = SocketServer.TCPServer(("", yaml_server.__config__["port"]), YamlServerRequestHandler)
         except Exception, e:
             self.logger.fatal("Could not start server: %s" % str(e))


### PR DESCRIPTION
Some issues were detected when trying to restart the yaml_server. We observed
that sometimes, when you try to restart the server, it wouldn't come back up.
Upon further investigation this seemed to be reproducible, when performing a
get request---using curl---immediately prior to attempting to restart the
server.  When looking at the log files, the following log message was observed
in syslog:

Mar  7 14:38:52 isdeblnwl081 yaml_server[23982]: CRITICAL: Could not start
server: [Errno 98] Address already in use

When using the google, the following stackoverflow post hinted at some
potential fixes:

http://stackoverflow.com/questions/15260558/python-tcpserver-address-already-in-use-but-i-close-the-server-and-i-use-allow

Implementing this fix, does solve problem, at least for the local test setup we
have.
